### PR TITLE
Add request URL conversion matrix support

### DIFF
--- a/store.cr
+++ b/store.cr
@@ -1,5 +1,7 @@
+BASE_DIR = "."
+
 class Store
-  def initialize(@base_dir = "./store")
+  def initialize(@base_dir = "#{BASE_DIR}/compiled")
     @resources = {} of String => String
   end
 


### PR DESCRIPTION
Add support to request resources through an URL shortcut, according to the following:

```
  Conversion matrix:

  GET /compiled-html-filename-without-extension -> /raw/html/filename-without-extension
  GET /filename.js -> /raw/js/filename-without-extension
  GET /filename.css -> /raw/css/filename-without-extension

```
